### PR TITLE
Fix applying colors incorrectly and use Compose Color for API

### DIFF
--- a/window-styler-demo/src/jvmMain/kotlin/Main.kt
+++ b/window-styler-demo/src/jvmMain/kotlin/Main.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.lightColors
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
@@ -54,12 +55,12 @@ fun main() = application {
 val themeOptions = listOf(false to "Light", true to "Dark")
 val backdropOptions = listOf(
     WindowBackdrop.Default to "Default",
-    WindowBackdrop.Solid(0xFF0000) to "Solid Red",
-    WindowBackdrop.Solid(0x0000FF) to "Solid Blue",
+    WindowBackdrop.Solid(Color.Red) to "Solid Red",
+    WindowBackdrop.Solid(Color.Blue) to "Solid Blue",
     WindowBackdrop.Transparent to "Transparent",
     WindowBackdrop.Aero to "Aero",
-    WindowBackdrop.Acrylic(0xFF0000) to "Acrylic Red",
-    WindowBackdrop.Acrylic(0x0000FF) to "Acrylic Blue",
+    WindowBackdrop.Acrylic(Color.Magenta.copy(alpha = 0.25F)) to "Acrylic Magenta",
+    WindowBackdrop.Acrylic(Color.Cyan.copy(alpha = 0.25F)) to "Acrylic Cyan",
     WindowBackdrop.Mica to "Mica",
     WindowBackdrop.Tabbed to "Tabbed",
 )

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/NativeUtils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/NativeUtils.kt
@@ -2,6 +2,7 @@ package com.mayakapps.compose.windowstyler
 
 import androidx.compose.ui.awt.ComposeWindow
 import com.mayakapps.compose.windowstyler.jna.Nt
+import com.mayakapps.compose.windowstyler.jna.enums.AccentState
 import com.mayakapps.compose.windowstyler.jna.enums.DwmSystemBackdrop
 import com.mayakapps.compose.windowstyler.jna.structs.OsVersionInfo
 import com.sun.jna.Native
@@ -27,4 +28,13 @@ internal fun WindowBackdrop.toDwmSystemBackdrop(): DwmSystemBackdrop =
         is WindowBackdrop.Acrylic -> DwmSystemBackdrop.DWMSBT_TRANSIENTWINDOW
         is WindowBackdrop.Tabbed -> DwmSystemBackdrop.DWMSBT_TABBEDWINDOW
         else -> DwmSystemBackdrop.DWMSBT_DISABLE
+    }
+
+
+internal fun WindowBackdrop.toAccentState(): AccentState =
+    when (this) {
+        is WindowBackdrop.Default, is WindowBackdrop.Solid -> AccentState.ACCENT_ENABLE_GRADIENT
+        is WindowBackdrop.Aero -> AccentState.ACCENT_ENABLE_BLURBEHIND
+        is WindowBackdrop.Acrylic -> AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND
+        else -> AccentState.ACCENT_DISABLED
     }

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
@@ -1,0 +1,18 @@
+package com.mayakapps.compose.windowstyler
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.colorspace.connect
+
+// Modified version of toArgb
+internal fun Color.toAbgr(): Int {
+    val colorSpace = colorSpace
+    val color = run { floatArrayOf(red, green, blue, alpha) }
+
+    // The transformation saturates the output
+    colorSpace.connect().transform(color)
+
+    return (color[3] * 255.0f + 0.5f).toInt() shl 24 or
+            ((color[2] * 255.0f + 0.5f).toInt() shl 16) or
+            ((color[1] * 255.0f + 0.5f).toInt() shl 8) or
+            (color[0] * 255.0f + 0.5f).toInt()
+}

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowBackdrop.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowBackdrop.kt
@@ -1,11 +1,17 @@
 package com.mayakapps.compose.windowstyler
 
+import androidx.compose.ui.graphics.Color
+
 sealed interface WindowBackdrop {
     object Default : WindowBackdrop
-    data class Solid(val color: Int) : WindowBackdrop
+    data class Solid(override val color: Color) : ColorableWindowBackdrop
     object Transparent : WindowBackdrop
     object Aero : WindowBackdrop
-    data class Acrylic(val color: Int) : WindowBackdrop
+    data class Acrylic(override val color: Color) : ColorableWindowBackdrop
     object Mica : WindowBackdrop
     object Tabbed : WindowBackdrop
+}
+
+internal interface ColorableWindowBackdrop : WindowBackdrop {
+    val color: Color
 }

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
@@ -11,7 +11,6 @@ import com.mayakapps.compose.windowstyler.WindowManager.setSystemBackdrop
 import com.mayakapps.compose.windowstyler.jna.enums.AccentFlag
 import com.mayakapps.compose.windowstyler.jna.enums.AccentState
 import javax.swing.SwingUtilities
-import javax.swing.UIManager
 
 @Composable
 fun FrameWindowScope.WindowStyle(
@@ -76,19 +75,9 @@ fun FrameWindowScope.WindowStyle(
 
                     setAccentPolicy(
                         hwnd = hwnd,
-                        accentState = when (backdropType) {
-                            is WindowBackdrop.Default, is WindowBackdrop.Solid -> AccentState.ACCENT_ENABLE_GRADIENT
-                            is WindowBackdrop.Aero -> AccentState.ACCENT_ENABLE_BLURBEHIND
-                            is WindowBackdrop.Acrylic -> AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND
-                            else -> throw IllegalStateException()
-                        },
+                        accentState = backdropType.toAccentState(),
                         accentFlags = setOf(AccentFlag.DRAW_ALL_BORDERS),
-                        color = when (backdropType) {
-                            is WindowBackdrop.Default -> UIManager.getColor("Panel.background").rgb
-                            is WindowBackdrop.Solid -> backdropType.color
-                            is WindowBackdrop.Acrylic -> backdropType.color
-                            else -> 0x7FFFFFFF
-                        },
+                        color = (backdropType as? ColorableWindowBackdrop)?.color?.toAbgr() ?: 0x0FFFFFFF,
                     )
                 }
             }


### PR DESCRIPTION
This pull request fixes an issue caused by supplying colors as integer (which is usually assumed to be ARGB) in place of ABGR integer. the API was updated to use Compose Color for better usability and to avoid problems like suppling an BGR to an ABGR argument making it fully transparent.