### PR TITLE
Use WindowScope as receiver

### DIFF
--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/NativeUtils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/NativeUtils.kt
@@ -8,9 +8,9 @@ import com.mayakapps.compose.windowstyler.jna.structs.OsVersionInfo
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.WinDef
-import javax.swing.JFrame
+import java.awt.Window
 
-internal val JFrame.hwnd
+internal val Window.hwnd
     get() =
         if (this is ComposeWindow) WinDef.HWND(Pointer(windowHandle))
         else WinDef.HWND(Native.getWindowPointer(this))

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/TransparencyUtils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/TransparencyUtils.kt
@@ -5,8 +5,8 @@ import org.jetbrains.skiko.SkiaLayer
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
+import java.awt.Window
 import javax.swing.JComponent
-import javax.swing.JFrame
 
 internal fun ComposeWindow.setComposeLayerTransparency(isTransparent: Boolean) {
     val delegate = delegateField.get(this@setComposeLayerTransparency)
@@ -16,7 +16,9 @@ internal fun ComposeWindow.setComposeLayerTransparency(isTransparent: Boolean) {
     component.transparency = isTransparent
 }
 
-internal fun JFrame.hackContentPane() {
+internal fun Window.hackContentPane() {
+    val oldContentPane = contentPane ?: return
+
     // Create hacked content pane the same way of AWT
     val newContentPane: JComponent = HackedContentPane()
     newContentPane.name = "$name.contentPane"
@@ -28,7 +30,7 @@ internal fun JFrame.hackContentPane() {
 
     newContentPane.background = Color(0, 0, 0, 0)
 
-    contentPane.components.forEach { newContentPane.add(it) }
+    oldContentPane.components.forEach { newContentPane.add(it) }
 
     contentPane = newContentPane
 }

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
@@ -2,6 +2,10 @@ package com.mayakapps.compose.windowstyler
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.connect
+import java.awt.Window
+import javax.swing.JDialog
+import javax.swing.JFrame
+import javax.swing.JWindow
 
 // Modified version of toArgb
 internal fun Color.toAbgr(): Int {
@@ -21,3 +25,18 @@ internal fun Color.toAbgr(): Int {
 // transparent accent policy results in solid red color. As a workaround, we pass
 // fully transparent white which has the same visual effect.
 internal fun Color.toAbgrForTransparent() = if (alpha == 0F) 0x00FFFFFF else toAbgr()
+
+// Try hard to get the contentPane
+internal var Window.contentPane
+    get() = when (this) {
+        is JFrame -> contentPane
+        is JDialog -> contentPane
+        is JWindow -> contentPane
+        else -> null
+    }
+    set(value) = when (this) {
+        is JFrame -> contentPane = value
+        is JDialog -> contentPane = value
+        is JWindow -> contentPane = value
+        else -> throw IllegalStateException()
+    }

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowManager.kt
@@ -6,11 +6,11 @@ import com.mayakapps.compose.windowstyler.jna.enums.AccentFlag
 import com.mayakapps.compose.windowstyler.jna.enums.AccentState
 import com.mayakapps.compose.windowstyler.jna.enums.DwmSystemBackdrop
 import com.sun.jna.platform.win32.WinDef.HWND
-import javax.swing.JFrame
+import java.awt.Window
 import javax.swing.SwingUtilities
 
 class WindowManager(
-    window: JFrame,
+    window: Window,
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
 ) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
@@ -3,10 +3,10 @@ package com.mayakapps.compose.windowstyler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.WindowScope
 
 @Composable
-fun FrameWindowScope.WindowStyle(
+fun WindowScope.WindowStyle(
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
 ) {


### PR DESCRIPTION
Closes #15 

This PR changes the receviver of `WindowStyle` to use `WindowScope`. This allows using third party libraries as shown in the issue.

For this change, I had to create an extension function which tries to get a content pane by guessing the type of `Window`.