### PR TITLE
Add a workaround for transparent decorated windows

### DIFF
--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/TransparencyUtils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/TransparencyUtils.kt
@@ -2,11 +2,10 @@ package com.mayakapps.compose.windowstyler
 
 import androidx.compose.ui.awt.ComposeWindow
 import org.jetbrains.skiko.SkiaLayer
-import java.awt.BorderLayout
-import java.awt.Color
-import java.awt.Component
-import java.awt.Window
+import java.awt.*
 import javax.swing.JComponent
+import javax.swing.JDialog
+import javax.swing.JWindow
 
 internal fun ComposeWindow.setComposeLayerTransparency(isTransparent: Boolean) {
     val delegate = delegateField.get(this@setComposeLayerTransparency)
@@ -34,6 +33,15 @@ internal fun Window.hackContentPane() {
 
     contentPane = newContentPane
 }
+
+
+internal val Window.isUndecorated
+    get() = when (this) {
+        is Frame -> isUndecorated
+        is JDialog -> isUndecorated
+        is JWindow -> true
+        else -> false
+    }
 
 
 private val delegateField by lazy {


### PR DESCRIPTION
This PR adds a workaround for applying `Transparent` effect on decorated windows. This done by reapplying the effect on each focus change. This might be inefficient but still enough for the limited use cases of transparent window with borders.

This PR closes #13. If you have better solution for this issue, feel free to leave a comment there.