### PR TITLE
Move windows implementation to sub-package and provide stub implementation to other OSes

### DIFF
--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/OsType.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/OsType.kt
@@ -1,0 +1,21 @@
+package com.mayakapps.compose.windowstyler
+
+internal enum class OsType {
+    UNKNOWN,
+    WINDOWS,
+    LINUX,
+    MACOS,
+    ;
+
+    companion object {
+        val current by lazy {
+            val osName = System.getProperty("os.name") ?: return@lazy UNKNOWN
+            when {
+                osName.startsWith("Windows", ignoreCase = true) -> WINDOWS
+                osName.startsWith("Linux", ignoreCase = true) -> LINUX
+                osName.startsWith("Mac", ignoreCase = true) -> MACOS
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/Utils.kt
@@ -1,30 +1,9 @@
 package com.mayakapps.compose.windowstyler
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.colorspace.connect
 import java.awt.Window
 import javax.swing.JDialog
 import javax.swing.JFrame
 import javax.swing.JWindow
-
-// Modified version of toArgb
-internal fun Color.toAbgr(): Int {
-    val colorSpace = colorSpace
-    val color = run { floatArrayOf(red, green, blue, alpha) }
-
-    // The transformation saturates the output
-    colorSpace.connect().transform(color)
-
-    return (color[3] * 255.0f + 0.5f).toInt() shl 24 or
-            ((color[2] * 255.0f + 0.5f).toInt() shl 16) or
-            ((color[1] * 255.0f + 0.5f).toInt() shl 8) or
-            (color[0] * 255.0f + 0.5f).toInt()
-}
-
-// For some reason, passing 0 (fully transparent black) to the setAccentPolicy with
-// transparent accent policy results in solid red color. As a workaround, we pass
-// fully transparent white which has the same visual effect.
-internal fun Color.toAbgrForTransparent() = if (alpha == 0F) 0x00FFFFFF else toAbgr()
 
 // Try hard to get the contentPane
 internal var Window.contentPane

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowManager.kt
@@ -1,0 +1,23 @@
+package com.mayakapps.compose.windowstyler
+
+import com.mayakapps.compose.windowstyler.windows.WindowsWindowManager
+import java.awt.Window
+
+fun WindowManager(
+    window: Window,
+    isDarkTheme: Boolean = false,
+    backdropType: WindowBackdrop = WindowBackdrop.Default,
+) = when (OsType.current) {
+    OsType.WINDOWS -> WindowsWindowManager(window, isDarkTheme, backdropType)
+    else -> StubWindowManager(isDarkTheme, backdropType)
+}
+
+interface WindowManager {
+    var isDarkTheme: Boolean
+    var backdropType: WindowBackdrop
+}
+
+internal class StubWindowManager(
+    override var isDarkTheme: Boolean,
+    override var backdropType: WindowBackdrop,
+) : WindowManager

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
@@ -4,14 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.window.WindowScope
-import com.mayakapps.compose.windowstyler.windows.WindowsWindowManager
 
 @Composable
 fun WindowScope.WindowStyle(
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
 ) {
-    val manager = remember { WindowsWindowManager(window, isDarkTheme, backdropType) }
+    val manager = remember { WindowManager(window, isDarkTheme, backdropType) }
 
     LaunchedEffect(isDarkTheme) {
         manager.isDarkTheme = isDarkTheme

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
@@ -4,13 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.window.WindowScope
+import com.mayakapps.compose.windowstyler.windows.WindowsWindowManager
 
 @Composable
 fun WindowScope.WindowStyle(
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
 ) {
-    val manager = remember { WindowManager(window, isDarkTheme, backdropType) }
+    val manager = remember { WindowsWindowManager(window, isDarkTheme, backdropType) }
 
     LaunchedEffect(isDarkTheme) {
         manager.isDarkTheme = isDarkTheme

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/Native.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/Native.kt
@@ -1,12 +1,12 @@
-package com.mayakapps.compose.windowstyler
+package com.mayakapps.compose.windowstyler.windows
 
-import com.mayakapps.compose.windowstyler.jna.Dwm
-import com.mayakapps.compose.windowstyler.jna.DwmSetWindowAttribute
-import com.mayakapps.compose.windowstyler.jna.User32
-import com.mayakapps.compose.windowstyler.jna.enums.*
-import com.mayakapps.compose.windowstyler.jna.structs.AccentPolicy
-import com.mayakapps.compose.windowstyler.jna.structs.Margins
-import com.mayakapps.compose.windowstyler.jna.structs.WindowCompositionAttributeData
+import com.mayakapps.compose.windowstyler.windows.jna.Dwm
+import com.mayakapps.compose.windowstyler.windows.jna.DwmSetWindowAttribute
+import com.mayakapps.compose.windowstyler.windows.jna.User32
+import com.mayakapps.compose.windowstyler.windows.jna.enums.*
+import com.mayakapps.compose.windowstyler.windows.jna.structs.AccentPolicy
+import com.mayakapps.compose.windowstyler.windows.jna.structs.Margins
+import com.mayakapps.compose.windowstyler.windows.jna.structs.WindowCompositionAttributeData
 import com.sun.jna.Native
 import com.sun.jna.platform.win32.W32Errors
 import com.sun.jna.platform.win32.WinDef

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/NativeUtils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/NativeUtils.kt
@@ -1,10 +1,11 @@
-package com.mayakapps.compose.windowstyler
+package com.mayakapps.compose.windowstyler.windows
 
 import androidx.compose.ui.awt.ComposeWindow
-import com.mayakapps.compose.windowstyler.jna.Nt
-import com.mayakapps.compose.windowstyler.jna.enums.AccentState
-import com.mayakapps.compose.windowstyler.jna.enums.DwmSystemBackdrop
-import com.mayakapps.compose.windowstyler.jna.structs.OsVersionInfo
+import com.mayakapps.compose.windowstyler.WindowBackdrop
+import com.mayakapps.compose.windowstyler.windows.jna.Nt
+import com.mayakapps.compose.windowstyler.windows.jna.enums.AccentState
+import com.mayakapps.compose.windowstyler.windows.jna.enums.DwmSystemBackdrop
+import com.mayakapps.compose.windowstyler.windows.jna.structs.OsVersionInfo
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.platform.win32.WinDef
@@ -28,7 +29,6 @@ internal fun WindowBackdrop.toDwmSystemBackdrop(): DwmSystemBackdrop =
         is WindowBackdrop.Tabbed -> DwmSystemBackdrop.DWMSBT_TABBEDWINDOW
         else -> DwmSystemBackdrop.DWMSBT_DISABLE
     }
-
 
 internal fun WindowBackdrop.toAccentState(): AccentState =
     when (this) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/Utils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/Utils.kt
@@ -1,0 +1,23 @@
+package com.mayakapps.compose.windowstyler.windows
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.colorspace.connect
+
+// Modified version of toArgb
+internal fun Color.toAbgr(): Int {
+    val colorSpace = colorSpace
+    val color = run { floatArrayOf(red, green, blue, alpha) }
+
+    // The transformation saturates the output
+    colorSpace.connect().transform(color)
+
+    return (color[3] * 255.0f + 0.5f).toInt() shl 24 or
+            ((color[2] * 255.0f + 0.5f).toInt() shl 16) or
+            ((color[1] * 255.0f + 0.5f).toInt() shl 8) or
+            (color[0] * 255.0f + 0.5f).toInt()
+}
+
+// For some reason, passing 0 (fully transparent black) to the setAccentPolicy with
+// transparent accent policy results in solid red color. As a workaround, we pass
+// fully transparent white which has the same visual effect.
+internal fun Color.toAbgrForTransparent() = if (alpha == 0F) 0x00FFFFFF else toAbgr()

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowManager.kt
@@ -16,12 +16,12 @@ class WindowsWindowManager(
     window: Window,
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
-) {
+): WindowManager {
 
     private val hwnd: HWND = window.hwnd
     private val isUndecorated = window.isUndecorated
 
-    var isDarkTheme: Boolean = isDarkTheme
+    override var isDarkTheme: Boolean = isDarkTheme
         set(value) {
             if (field != value) {
                 field = value
@@ -29,7 +29,7 @@ class WindowsWindowManager(
             }
         }
 
-    var backdropType: WindowBackdrop = backdropType
+    override var backdropType: WindowBackdrop = backdropType
         set(value) {
             val finalValue = value.fallbackIfUnsupported()
 

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowManager.kt
@@ -1,17 +1,18 @@
-package com.mayakapps.compose.windowstyler
+package com.mayakapps.compose.windowstyler.windows
 
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
-import com.mayakapps.compose.windowstyler.jna.enums.AccentFlag
-import com.mayakapps.compose.windowstyler.jna.enums.AccentState
-import com.mayakapps.compose.windowstyler.jna.enums.DwmSystemBackdrop
+import com.mayakapps.compose.windowstyler.*
+import com.mayakapps.compose.windowstyler.windows.jna.enums.AccentFlag
+import com.mayakapps.compose.windowstyler.windows.jna.enums.AccentState
+import com.mayakapps.compose.windowstyler.windows.jna.enums.DwmSystemBackdrop
 import com.sun.jna.platform.win32.WinDef.HWND
 import java.awt.Window
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.SwingUtilities
 
-class WindowManager(
+class WindowsWindowManager(
     window: Window,
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
@@ -47,7 +48,7 @@ class WindowManager(
         override fun windowLostFocus(e: WindowEvent?) = resetTransparent()
 
         private fun resetTransparent() {
-            if (!isUndecorated && this@WindowManager.backdropType is WindowBackdrop.Transparent) {
+            if (!isUndecorated && this@WindowsWindowManager.backdropType is WindowBackdrop.Transparent) {
                 resetAccentPolicy()
                 updateBackdrop()
             }

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Dwm.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Dwm.kt
@@ -1,7 +1,7 @@
-package com.mayakapps.compose.windowstyler.jna
+package com.mayakapps.compose.windowstyler.windows.jna
 
-import com.mayakapps.compose.windowstyler.jna.enums.DwmWindowAttribute
-import com.mayakapps.compose.windowstyler.jna.structs.Margins
+import com.mayakapps.compose.windowstyler.windows.jna.enums.DwmWindowAttribute
+import com.mayakapps.compose.windowstyler.windows.jna.structs.Margins
 import com.sun.jna.Native
 import com.sun.jna.PointerType
 import com.sun.jna.platform.win32.WinDef.HWND

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Nt.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Nt.kt
@@ -1,6 +1,6 @@
-package com.mayakapps.compose.windowstyler.jna
+package com.mayakapps.compose.windowstyler.windows.jna
 
-import com.mayakapps.compose.windowstyler.jna.structs.OsVersionInfo
+import com.mayakapps.compose.windowstyler.windows.jna.structs.OsVersionInfo
 import com.sun.jna.Native
 import com.sun.jna.win32.StdCallLibrary
 import com.sun.jna.win32.W32APIOptions

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/User32.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/User32.kt
@@ -1,6 +1,6 @@
-package com.mayakapps.compose.windowstyler.jna
+package com.mayakapps.compose.windowstyler.windows.jna
 
-import com.mayakapps.compose.windowstyler.jna.structs.WindowCompositionAttributeData
+import com.mayakapps.compose.windowstyler.windows.jna.structs.WindowCompositionAttributeData
 import com.sun.jna.Native
 import com.sun.jna.platform.win32.WinDef
 import com.sun.jna.win32.StdCallLibrary

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Utils.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/Utils.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna
+package com.mayakapps.compose.windowstyler.windows.jna
 
 internal inline fun <T> Iterable<T>.orOf(selector: (T) -> Int): Int {
     var result = 0

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/AccentFlag.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/AccentFlag.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.enums
+package com.mayakapps.compose.windowstyler.windows.jna.enums
 
 @Suppress("SpellCheckingInspection", "unused")
 enum class AccentFlag(val value: Int) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/AccentState.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/AccentState.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.enums
+package com.mayakapps.compose.windowstyler.windows.jna.enums
 
 @Suppress("SpellCheckingInspection", "unused")
 internal enum class AccentState(val value: Int) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/DwmSystemBackdrop.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/DwmSystemBackdrop.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.enums
+package com.mayakapps.compose.windowstyler.windows.jna.enums
 
 import com.sun.jna.ptr.IntByReference
 

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/DwmWindowAttribute.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/DwmWindowAttribute.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.enums
+package com.mayakapps.compose.windowstyler.windows.jna.enums
 
 @Suppress("SpellCheckingInspection", "unused")
 internal enum class DwmWindowAttribute(val value: Int) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/WindowCompositionAttribute.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/enums/WindowCompositionAttribute.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.enums
+package com.mayakapps.compose.windowstyler.windows.jna.enums
 
 @Suppress("SpellCheckingInspection", "unused")
 internal enum class WindowCompositionAttribute(val value: Int) {

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/AccentPolicy.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/AccentPolicy.kt
@@ -1,8 +1,8 @@
-package com.mayakapps.compose.windowstyler.jna.structs
+package com.mayakapps.compose.windowstyler.windows.jna.structs
 
-import com.mayakapps.compose.windowstyler.jna.enums.AccentFlag
-import com.mayakapps.compose.windowstyler.jna.enums.AccentState
-import com.mayakapps.compose.windowstyler.jna.orOf
+import com.mayakapps.compose.windowstyler.windows.jna.enums.AccentFlag
+import com.mayakapps.compose.windowstyler.windows.jna.enums.AccentState
+import com.mayakapps.compose.windowstyler.windows.jna.orOf
 import com.sun.jna.Structure.FieldOrder
 
 @Suppress("unused")

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/BaseStructure.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/BaseStructure.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.structs
+package com.mayakapps.compose.windowstyler.windows.jna.structs
 
 import com.sun.jna.Structure
 

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/Margins.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/Margins.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.structs
+package com.mayakapps.compose.windowstyler.windows.jna.structs
 
 import com.sun.jna.Structure
 

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/OsVersionInfo.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/OsVersionInfo.kt
@@ -1,4 +1,4 @@
-package com.mayakapps.compose.windowstyler.jna.structs
+package com.mayakapps.compose.windowstyler.windows.jna.structs
 
 import com.sun.jna.Pointer
 import com.sun.jna.Structure.FieldOrder

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/WindowCompositionAttributeData.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/jna/structs/WindowCompositionAttributeData.kt
@@ -1,6 +1,6 @@
-package com.mayakapps.compose.windowstyler.jna.structs
+package com.mayakapps.compose.windowstyler.windows.jna.structs
 
-import com.mayakapps.compose.windowstyler.jna.enums.WindowCompositionAttribute
+import com.mayakapps.compose.windowstyler.windows.jna.enums.WindowCompositionAttribute
 import com.sun.jna.Structure.FieldOrder
 
 @Suppress("unused")


### PR DESCRIPTION
This PR moves windows implementation to `com.mayakapps.compose.windowstyler.windows` including renaming current `WindowManager` to `WindowsWindowManager`, which is replaced by an interface and factory function which won't have API-breaking effect as both of them have the same name, package, arguments, and syntax.

This change allows using `WindowStyle` directly on multi-OS desktop application without crashing on OSes other than Windows. This also allows possible future implementations to other OSes.