### PR TITLE
Some changes to Transparent effect and refactoring

### DIFF
--- a/window-styler-demo/src/jvmMain/kotlin/Main.kt
+++ b/window-styler-demo/src/jvmMain/kotlin/Main.kt
@@ -63,7 +63,7 @@ val backdropOptions = listOf(
     WindowBackdrop.Default to "Default",
     WindowBackdrop.Solid(Color.Red) to "Solid Red",
     WindowBackdrop.Solid(Color.Blue) to "Solid Blue",
-    WindowBackdrop.Transparent(Color.Transparent) to "Transparent",
+    WindowBackdrop.Transparent to "Transparent",
     WindowBackdrop.Transparent(Color.Yellow.copy(alpha = 0.25F)) to "Yellow Transparent",
     WindowBackdrop.Aero to "Aero",
     WindowBackdrop.Acrylic(Color.Magenta.copy(alpha = 0.25F)) to "Acrylic Magenta",

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowBackdrop.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowBackdrop.kt
@@ -10,20 +10,35 @@ sealed interface WindowBackdrop {
         override val supportedSince: Int = 0 // Unknown but old
     }
 
-    data class Solid(override val color: Color) : WindowBackdrop, ColorableWindowBackdrop {
+    open class Solid(override val color: Color) : WindowBackdrop, ColorableWindowBackdrop {
         override val supportedSince: Int = 0 // Unknown but old
+
+        override fun equals(other: Any?): Boolean = equalsImpl(other)
+        override fun hashCode(): Int = hashCodeImpl()
     }
 
-    data class Transparent(override val color: Color) : WindowBackdrop, ColorableWindowBackdrop {
+    open class Transparent(color: Color) : WindowBackdrop, ColorableWindowBackdrop {
+        // If you really want the color to be fully opaque, just use Solid which is simpler and more stable
+        override val color: Color =
+            if (color.alpha != 1F) color else color.copy(alpha = 0.5F)
+
         override val supportedSince: Int = 0 // Unknown but old
+
+        override fun equals(other: Any?): Boolean = equalsImpl(other)
+        override fun hashCode(): Int = hashCodeImpl()
+
+        companion object : Transparent(Color.Transparent)
     }
 
     object Aero : WindowBackdrop {
         override val supportedSince: Int = 0 // Unknown but old
     }
 
-    data class Acrylic(override val color: Color) : WindowBackdrop, ColorableWindowBackdrop {
+    open class Acrylic(override val color: Color) : WindowBackdrop, ColorableWindowBackdrop {
         override val supportedSince: Int = 17063
+
+        override fun equals(other: Any?): Boolean = equalsImpl(other)
+        override fun hashCode(): Int = hashCodeImpl()
     }
 
     object Mica : WindowBackdrop {
@@ -37,4 +52,15 @@ sealed interface WindowBackdrop {
 
 internal sealed interface ColorableWindowBackdrop {
     val color: Color
+
+    fun equalsImpl(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ColorableWindowBackdrop
+
+        return color == other.color
+    }
+
+    fun hashCodeImpl(): Int = color.hashCode()
 }


### PR DESCRIPTION
This PR adds default `Transparent` backdrop which maps to fully transparent backdrop. It also changes opaque colors passed to `Transparent` to be semi-opaque as it makes no sense to have opaque color in transparent effect.

The themed acrylic and transparent effects used as fallbacks were also refactored to get rid of using reference equality.