### PR TITLE
Rename WindowManager to WindowStyleManager

### DIFF
--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyle.kt
@@ -11,7 +11,7 @@ fun WindowScope.WindowStyle(
     backdropType: WindowBackdrop = WindowBackdrop.Default,
     frameStyle: WindowFrameStyle = WindowFrameStyle(),
 ) {
-    val manager = remember { WindowManager(window, isDarkTheme, backdropType, frameStyle) }
+    val manager = remember { WindowStyleManager(window, isDarkTheme, backdropType, frameStyle) }
 
     LaunchedEffect(isDarkTheme) {
         manager.isDarkTheme = isDarkTheme

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyleManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/WindowStyleManager.kt
@@ -1,28 +1,28 @@
 package com.mayakapps.compose.windowstyler
 
-import com.mayakapps.compose.windowstyler.windows.WindowsWindowManager
+import com.mayakapps.compose.windowstyler.windows.WindowsWindowStyleManager
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import java.awt.Window
 
-fun WindowManager(
+fun WindowStyleManager(
     window: Window,
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
     frameStyle: WindowFrameStyle = WindowFrameStyle(),
 ) = when (hostOs) {
-    OS.Windows -> WindowsWindowManager(window, isDarkTheme, backdropType, frameStyle)
-    else -> StubWindowManager(isDarkTheme, backdropType, frameStyle)
+    OS.Windows -> WindowsWindowStyleManager(window, isDarkTheme, backdropType, frameStyle)
+    else -> StubWindowStyleManager(isDarkTheme, backdropType, frameStyle)
 }
 
-interface WindowManager {
+interface WindowStyleManager {
     var isDarkTheme: Boolean
     var backdropType: WindowBackdrop
     var frameStyle: WindowFrameStyle
 }
 
-internal class StubWindowManager(
+internal class StubWindowStyleManager(
     override var isDarkTheme: Boolean,
     override var backdropType: WindowBackdrop,
     override var frameStyle: WindowFrameStyle,
-) : WindowManager
+) : WindowStyleManager

--- a/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowStyleManager.kt
+++ b/window-styler/src/jvmMain/kotlin/com/mayakapps/compose/windowstyler/windows/WindowsWindowStyleManager.kt
@@ -13,12 +13,12 @@ import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.SwingUtilities
 
-class WindowsWindowManager(
+class WindowsWindowStyleManager(
     window: Window,
     isDarkTheme: Boolean = false,
     backdropType: WindowBackdrop = WindowBackdrop.Default,
     frameStyle: WindowFrameStyle = WindowFrameStyle(),
-) : WindowManager {
+) : WindowStyleManager {
 
     private val hwnd: HWND = window.hwnd
     private val isUndecorated = window.isUndecorated
@@ -228,7 +228,7 @@ class WindowsWindowManager(
         override fun windowLostFocus(e: WindowEvent?) = resetTransparent()
 
         private fun resetTransparent() {
-            if (!isUndecorated && this@WindowsWindowManager.backdropType is WindowBackdrop.Transparent) updateBackdrop()
+            if (!isUndecorated && this@WindowsWindowStyleManager.backdropType is WindowBackdrop.Transparent) updateBackdrop()
         }
     }
 


### PR DESCRIPTION
This is done for clarification. Though it is API-breaking in concept the class wasn't yet intended to be used by library users.