### PR TITLE
feat: library updates and removed refl/introspection for Skia

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 kotlin.code.style=official
-kotlin.version=1.6.10
-compose.version=1.1.1
+kotlin.version=1.9.0
+compose.version=1.5.0
+kotlin.experimental.tryK2=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.7.20"
-compose = "1.2.2"
+kotlin = "1.9.10"
+compose = "1.5.1"
 
 jna = "5.13.0"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,6 @@
 pluginManagement {
     repositories {
         google()
-        gradlePluginPortal()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }

--- a/window-styler-demo/build.gradle.kts
+++ b/window-styler-demo/build.gradle.kts
@@ -8,11 +8,9 @@ plugins {
 }
 
 kotlin {
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "11"
-        }
+    jvmToolchain(17)
 
+    jvm {
         withJava()
     }
 

--- a/window-styler/build.gradle.kts
+++ b/window-styler/build.gradle.kts
@@ -12,11 +12,8 @@ group = extra["GROUP"] as String
 version = extra["VERSION_NAME"] as String
 
 kotlin {
+    jvmToolchain(17)
     jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "11"
-        }
-
         withJava()
     }
 


### PR DESCRIPTION
Updated Kotlin
Updated Compose
Updated Java to 17 (needed for the latest packaging method)
Removed Kotlin reflection/introspection for finding Skia, instead used plain recursive component finding. See https://github.com/JetBrains/compose-multiplatform/issues/1660#issuecomment-1718988744 for more info